### PR TITLE
Updated aiohttp and bumped up the Python requirement accordingly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     azure-iot-device==2.9.0
-    aiohttp>=3.8.1,<=3.8.9
+    aiohttp>=3.8.1,<=3.10.0
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
The latest Home Assistant beta bumped up the aiohttp requirement and breaks this package. I have updated the dependency and bumped up the required python version to match